### PR TITLE
Small build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,7 @@ build/ndk-include/_proto:
 
 projects/NDK_3.9.info: download/NDK39.lha $(shell find 2>/dev/null patches/NDK_3.9/ -type f)
 	mkdir -p projects
-	if [ ! -e "$$(which lha)" ]; then cd build && rm -rf lha; git clone https://github.com/jca02266/lha; cd lha; aclocal; autoheader; automake -a; autoconf; ./configure; make all; install src/lha$(EXEEXT) /usr/bin; fi
+	if [ ! -e "$$(which lha)" ]; then cd build && rm -rf lha; git clone https://github.com/jca02266/lha; cd lha; aclocal; autoheader; automake -a; autoconf; ./configure; make all; install src/lha$(EXEEXT) $(PREFIX)/bin; fi
 	cd projects && lha xf ../download/NDK39.lha
 	touch -t 0001010000 download/NDK39.lha
 	for i in $$(find patches/NDK_3.9/ -type f); \

--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ build/ndk-include/_ndk13: build/ndk-include/_ndk
 	while read p; do \
 	  mkdir -p $(PREFIX)/m68k-amigaos/ndk13-include/$$(dirname $$p); \
 	  if grep V36 $(PREFIX)/m68k-amigaos/ndk-include/$$p; then \
-	  sed -n -e '/#ifndef  CLIB/,/V36/p' $(PREFIX)/m68k-amigaos/ndk-include/$$p >$(PREFIX)/m68k-amigaos/ndk13-include/$$p; \
+	  LC_CTYPE=C sed -n -e '/#ifndef  CLIB/,/V36/p' $(PREFIX)/m68k-amigaos/ndk-include/$$p >$(PREFIX)/m68k-amigaos/ndk13-include/$$p; \
 	  echo -e "#ifdef __cplusplus\n}\n#endif /* __cplusplus */\n#endif" >>$(PREFIX)/m68k-amigaos/ndk13-include/$$p; \
 	  else cp $(PREFIX)/m68k-amigaos/ndk-include/$$p $(PREFIX)/m68k-amigaos/ndk13-include/$$p; fi \
 	done < patches/ndk13/chfiles
@@ -528,7 +528,7 @@ build/ndk-include/_ndk13: build/ndk-include/_ndk
 	echo '#undef	EXECNAME' > $(PREFIX)/m68k-amigaos/ndk13-include/exec/execname.h
 	echo '#define	EXECNAME	"exec.library"' >> $(PREFIX)/m68k-amigaos/ndk13-include/exec/execname.h
 	mkdir -p $(PREFIX)/m68k-amigaos/ndk/lib/fd13
-	while read p; do sed -n -e '/##base/,/V36/P'  $(PREFIX)/m68k-amigaos/ndk/lib/fd/$$p >$(PREFIX)/m68k-amigaos/ndk/lib/fd13/$$p; done < patches/ndk13/fdfiles
+	while read p; do LC_CTYPE=C sed -n -e '/##base/,/V36/P'  $(PREFIX)/m68k-amigaos/ndk/lib/fd/$$p >$(PREFIX)/m68k-amigaos/ndk/lib/fd13/$$p; done < patches/ndk13/fdfiles
 	mkdir -p $(PREFIX)/m68k-amigaos/ndk/lib/sfd13
 	for i in $(PREFIX)/m68k-amigaos/ndk/lib/fd13/*; do fd2sfd $$i $(PREFIX)/m68k-amigaos/ndk13-include/clib/$$(basename $$i _lib.fd)_protos.h > $(PREFIX)/m68k-amigaos/ndk/lib/sfd13/$$(basename $$i .fd).sfd; done
 	for i in $(PREFIX)/m68k-amigaos/ndk/lib/sfd13/*; do \


### PR DESCRIPTION
Stumbled into a few minor painpoints trying to crosscompile on macos.

* Installing lha into a system path is a big no-no on any system - you've got an installation prefix, so please use it.
* You must assert a C CTYPE when using sed or other locale-aware tools to crunch Amiga native files.  ndk13 was causing errors in macos sed due to invalid byte sequences as the global LANG is set per your system locale and assumes UTF-8.  Forcing this to C eliminates any form of stream sanity checking and prevents locale-sensitive translations occurring.