### PR TITLE
Build instructions for macOS added.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include disable_implicite_rules.mk
 # =================================================
 PREFIX ?= /opt/amiga
 export PATH := $(PREFIX)/bin:$(PATH)
-SHELL = /bin/bash
+SHELL ?= /bin/bash
 
 GCC_GIT ?= https://github.com/bebbo/gcc
 GCC_BRANCH ?= gcc-6-branch

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Right now these tools are build:
 `sudo yum install gcc gcc-c++ python git perl-Pod-Simple gperf patch autoconf automake make makedepend bison flex ncurses-devel gmp-devel mpfr-devel libmpc-devel gettext-devel texinfo`
 ### Ubuntu
 `sudo apt install make git gcc g++ lhasa libgmp-dev libmpfr-dev libmpc-dev flex gettext texinfo`
+### macOS
+Install Homebrew (https://brew.sh/) or any other package manager first. The compiler will be installed together with XCode. Once XCode and Homebrew are up install the required packages:
+
+`brew install bash make lhasa gmp mpfr mpc fles gettext texinfo`
+
+By default macOS uses an outdated version of bash. Therefore, on macOS host always pass the the SHELL=/usr/local/bin/bash parameter (or any other valid path pointing to bash), e.g.:
+```
+make all SHELL=/usr/local/bin/bash
+```
+On macOS it may be also necessary to point to the correct compiler version (there is a gcc wrapper for clang, which can produce compile errors!), e.g.:
+```
+CC=clang CXX=clang++ make all SHELL=/usr/local/bin/bash
+```
+
 ### Windows with Cygwin
 Install cygwin via setup.exe and add wget. Then open cygwin shell and run:
 


### PR DESCRIPTION
I have just added build instructions for macOS host. They are pretty short and amiga-gcc builds there perfectly fine. I have also modified the Makefile slightly, in order to allow one to override the SHELL variable.

The change with SHELL is necessary since the bash version provided by macOS is relatively outdated and does not support e.g. the '|&' syntax which was used in the Makefile.