### PR TITLE
Camd

### DIFF
--- a/sdk/camd.sdk
+++ b/sdk/camd.sdk
@@ -1,0 +1,14 @@
+Short: 	CAMD developer kit for MorphOS
+Version: 37.1
+Url: http://aminet.net/dev/c/camd-morphos-dev.lha
+
+camd/clib/camd_protos.h
+camd/fd/camd_lib.fd = camd.fd
+camd/midi/camd.h
+camd/midi/camdbase.h
+camd/midi/mididefs.h
+camd/midi/midiprefs.h
+
+fd2sfd : camd.fd clib/camd_protos.h
+sfdc : camd.sfd 
+stubs : camd.sfd

--- a/sdk/guigfx.sdk
+++ b/sdk/guigfx.sdk
@@ -9,5 +9,5 @@ include/fd/guigfx_lib.fd
 include/guigfx/guigfx.h
 include/pragmas/guigfx_pragmas.h
 fd2sfd : guigfx_lib.fd clib/guigfx_protos.h
-sfdc : guigfx_lib.sfd
+sfdc : guigfx_lib.sfd guigfx.h guigfx_lib.h
 stubs : guigfx_lib.sfd

--- a/sdk/install
+++ b/sdk/install
@@ -117,11 +117,13 @@ case $1 in
 	    			fi
 	    			
     				dir=$(basename $(dirname $line))
+					#lower-case the directory part
+					outdir=${dir,,}
 	    			
 	    			if [[ $file == *.h ]] || [[ $file == *.i ]]; then
-						mkdir -p "$3/m68k-amigaos/include/$dir"
-						echo cp "build/$2/$line" "$3/m68k-amigaos/include/$dir/$file" 
-						cp "build/$2/$line" "$3/m68k-amigaos/include/$dir/$file" 
+						mkdir -p "$3/m68k-amigaos/include/$outdir"
+						echo cp "build/$2/$line" "$3/m68k-amigaos/include/$outdir/$file" 
+						cp "build/$2/$line" "$3/m68k-amigaos/include/$outdir/$file" 
 					elif [[ $file == *.guide ]]; then
 						mkdir -p "$3/m68k-amigaos/guide"
 						echo cp "build/$2/$line" "$3/m68k-amigaos/guide/$file" 

--- a/sdk/install
+++ b/sdk/install
@@ -57,14 +57,14 @@ case $1 in
     			mkdir -p $3/m68k-amigaos/include/inline/
     			$3/bin/sfdc --mode=macros --target=m68k-amigaos --output=$3/m68k-amigaos/include/inline/$name.h $3/m68k-amigaos/lib/sfd/$sfd || exit 1
     			mkdir -p $3/m68k-amigaos/include/lvo/
-    			$3/bin/sfdc --mode=lvo --target=m68k-amigaos --output=$3/m68k-amigaos/include/proto/$name.i $3/m68k-amigaos/lib/sfd/$sfd || exit 1
+    			$3/bin/sfdc --mode=lvo --target=m68k-amigaos --output=$3/m68k-amigaos/include/lvo/$name.i $3/m68k-amigaos/lib/sfd/$sfd || exit 1
     			if [ "${a[2]}" != "" ] && [ "${a[3]}" != "" ]; then
     				echo fixup names from ${a[2]} to ${a[3]}
     				echo sed -i.bak -e "s/${a[2]}/${a[3]}/" $3/m68k-amigaos/include/proto/$name.h
     				sed -i.bak -e "s/${a[2]}/${a[3]}/" $3/m68k-amigaos/include/proto/$name.h 
-    				sed -i.bak -e "s/${a[2]}/${a[3]}/" $3/m68k-amigaos/include/proto/$name.i
+    				sed -i.bak -e "s/${a[2]}/${a[3]}/" $3/m68k-amigaos/include/lvo/$name.i
     				sed -i.bak -e "s/${a[2]}/${a[3]}/" $3/m68k-amigaos/include/inline/$name.h
-    				rm $3/m68k-amigaos/include/proto/$name.h.bak $3/m68k-amigaos/include/proto/$name.i.bak $3/m68k-amigaos/include/inline/$name.h.bak 
+    				rm $3/m68k-amigaos/include/proto/$name.h.bak $3/m68k-amigaos/include/lvo/$name.i.bak $3/m68k-amigaos/include/inline/$name.h.bak 
     			fi
     		;;
     		stubs)

--- a/sdk/mcc_guigfx.sdk
+++ b/sdk/mcc_guigfx.sdk
@@ -1,0 +1,7 @@
+Short: Guigfx MUI custom class
+Version: 19.2
+Url: http://aminet.net/dev/mui/MCC_Guigfx.lha 
+
+MCC_Guigfx/Developer/Assembler/Include/MUI/Guigfx_mcc.i
+MCC_Guigfx/Developer/C/Include/MUI/Guigfx_mcc.h
+MCC_Guigfx/Developer/AutoDocs/Guigfx_mcc.doc = MCC_Guigfx.doc

--- a/sdk/mui.sdk
+++ b/sdk/mui.sdk
@@ -108,6 +108,6 @@ SDK/MUI/C/lib/libmui.a
 SDK/MUI/fd/muimaster_lib.fd
 SDK/MUI/sfd/muimaster_lib.sfd
 fd2sfd : muimaster_lib.fd clib/muimaster_protos.h
-sfdc : muimaster_lib.sfd
+sfdc : muimaster_lib.sfd muimaster.h muimaster_lib.h
 stubs : muimaster_lib.sfd
 lib : muimaster_lib.sfd


### PR DESCRIPTION
This adds CAMD headers to the toolchain. Since there seems to be no offical SDK for CAMD on Aminet, this takes some MorphOS headers and regenerates new proto files.
This includes the prior additions of Guigfx.
Please also note the change to  the location of the lvo files.

What I'm not sure how to deal with correctly is the whole _lib suffix business on headers. 
Why and when is it needed, when not?