### PR TITLE
MCC_TextEditor: version bump

### DIFF
--- a/sdk/mcc_texteditor.sdk
+++ b/sdk/mcc_texteditor.sdk
@@ -1,6 +1,6 @@
 Short: TextEditor custom class for MUI
-Version: 15.51
-Url: http://aminet.net/dev/mui/MCC_TextEditor-15.51.lha
+Version: 15.52
+Url: http://aminet.net/dev/mui/MCC_TextEditor-15.52.lha
 
 MCC_TextEditor/Developer/Autodocs/MCC/MCC_TextEditor.doc
 MCC_TextEditor/Developer/C/include/mui/TextEditor_mcc.h


### PR DESCRIPTION
Version 15.51 has been removed from Aminet and can't be found during `make all-sdk`, so we should update to 15.52.