### PR TITLE
Osx GDB build fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Output
 *.log
 .lock
 .state
+.vscode
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -326,10 +326,8 @@ BINUTILS := $(patsubst %,$(PREFIX)/bin/%$(EXEEXT), $(BINUTILS_CMD))
 BINUTILS_DIR := . bfd gas ld binutils opcodes
 BINUTILSD := $(patsubst %,projects/binutils/%, $(BINUTILS_DIR))
 
-ifeq ($(findstring Darwin,$(shell uname)),)
 ALL_GDB := all-gdb
 INSTALL_GDB := install-gdb
-endif
 
 binutils: $(BUILD)/binutils/_done
 
@@ -360,12 +358,10 @@ projects/binutils/configure:
 gdb: $(BUILD)/binutils/_gdb
 
 $(BUILD)/binutils/_gdb: $(BUILD)/binutils/_done
-ifneq (,$(ALL_GDB))
 	$(L0)"make binutils configure gdb"$(L1)$(MAKE) -C $(BUILD)/binutils configure-gdb $(L2)
 	$(L0)"make binutils gdb libs"$(L1)$(MAKE) -C $(BUILD)/binutils/gdb all-lib $(L2)
 	$(L0)"make binutils gdb"$(L1)$(MAKE) -C $(BUILD)/binutils $(ALL_GDB) $(L2)
 	$(L0)"install binutils gdb"$(L1)$(MAKE) -C $(BUILD)/binutils install-gas install-binutils install-ld $(INSTALL_GDB) $(L2)
-endif
 	@echo "done" >$@
 
 	
@@ -390,7 +386,12 @@ $(BUILD)/binutils/gprof/Makefile: projects/binutils/configure $(BUILD)/binutils/
 # =================================================
 CONFIG_GCC = --prefix=$(PREFIX) --target=m68k-amigaos --enable-languages=c,c++,objc --enable-version-specific-runtime-libs --disable-libssp --disable-nls \
 	--with-headers=$(PWD)/projects/newlib-cygwin/newlib/libc/sys/amigaos/include/ --disable-shared \
-	--with-stage1-ldflags="-dynamic-libgcc -dynamic-libstdc++" --with-boot-ldflags="-dynamic-libgcc -dynamic-libstdc++"
+	--with-stage1-ldflags="-dynamic-libgcc -dynamic-libstdc++" --with-boot-ldflags="-dynamic-libgcc -dynamic-libstdc++"	
+
+# OSX : libs added by the command brew install gmp mpfr libmpc
+ifeq ($(findstring Darwin,$(shell uname)),)
+CONFIG_GCC = ${CONFIG_GCC} --with-gmp="/usr/local/Cellar/gmp/6.1.2_2" --with-mpfr="/usr/local/Cellar/mpfr/4.0.2" --with-mpc="/usr/local/Cellar/libmpc/1.1.0"
+endif
 
 
 GCC_CMD := m68k-amigaos-c++ m68k-amigaos-g++ m68k-amigaos-gcc-$(GCC_VERSION) m68k-amigaos-gcc-nm \

--- a/Makefile
+++ b/Makefile
@@ -389,8 +389,8 @@ CONFIG_GCC = --prefix=$(PREFIX) --target=m68k-amigaos --enable-languages=c,c++,o
 	--with-stage1-ldflags="-dynamic-libgcc -dynamic-libstdc++" --with-boot-ldflags="-dynamic-libgcc -dynamic-libstdc++"	
 
 # OSX : libs added by the command brew install gmp mpfr libmpc
-ifeq ($(findstring Darwin,$(shell uname)),)
-CONFIG_GCC = ${CONFIG_GCC} --with-gmp="/usr/local/Cellar/gmp/6.1.2_2" --with-mpfr="/usr/local/Cellar/mpfr/4.0.2" --with-mpc="/usr/local/Cellar/libmpc/1.1.0"
+ifeq (Darwin, $(findstring Darwin, $(UNAME_S)))
+	CONFIG_GCC += --with-gmp-include=/usr/local/include --with-gmp-lib=/usr/local/lib --with-mpfr-include=/usr/local/include --with-mpfr-lib=/usr/local/lib --with-mpfr-include=/usr/local/include --with-mpfr-lib=/usr/local/lib
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ Right now these tools are build:
 ### macOS
 Install Homebrew (https://brew.sh/) or any other package manager first. The compiler will be installed together with XCode. Once XCode and Homebrew are up install the required packages:
 
-`brew install bash wget make lhasa gmp mpfr mpc flex gettext texinfo`
+`brew install bash wget make lhasa gmp mpfr libmpc flex gettext texinfo gcc make autoconf`
 
 By default macOS uses an outdated version of bash. Therefore, on macOS host always pass the the SHELL=/usr/local/bin/bash parameter (or any other valid path pointing to bash), e.g.:
 ```
 make all SHELL=/usr/local/bin/bash
 ```
-On macOS it may be also necessary to point to the correct compiler version (there is a gcc wrapper for clang, which can produce compile errors!), e.g.:
+On macOS it may be also necessary to point to the brew version of gcc make and autoconf, e.g.:
 ```
-CC=clang CXX=clang++ make all SHELL=/usr/local/bin/bash
+CC=gcc-9 CXX=g++-9 gmake all SHELL=/usr/local/bin/bash
 ```
 
 **ALSO NOTE** If you want `m68k-amigaos-gdb` then you have to build it with `gcc`


### PR DESCRIPTION
Builds on osx mojave 10.14.5.
I've used the gcc from brew, it resolved the compile errors.

I've tested the gdb build to debug with bgdbserver on vscode and it worked!