### PR TITLE
Adding instructions for creating Kickstart 1.3 executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ If you plan to develop for Kickstart 1.3 you should use `-mcrt=nix13` in your co
 m68k-amigaos-gcc test.cpp -mcrt=nix13
 ```
 
-The include files for 1.3 can be found at `<PREFIX>/m68k-amigaos/ndk13-include` i.E. `/opt/amiga/m68k-amigaos/ndk13-include`
+The include files for 1.3 - which are picked up by the compiler if `-mcrt=nix13` is used - can be found at `<PREFIX>/m68k-amigaos/ndk13-include` i.E. `/opt/amiga/m68k-amigaos/ndk13-include`

--- a/README.md
+++ b/README.md
@@ -106,3 +106,13 @@ make clean-prefix
 date; make all -j3 >&b.log; date
 ```
 takes roughly 10 minutes on my laptop running ubuntu. takes forever running cygwin on windows^^.
+
+## Kickstart 1.3
+
+If you plan to develop for Kickstart 1.3 you should use `-mcrt=nix13` in your compiler commandline
+
+```
+m68k-amigaos-gcc test.cpp -mcrt=nix13
+```
+
+The include files for 1.3 can be found at `<PREFIX>/m68k-amigaos/ndk13-include` i.E. `/opt/amiga/m68k-amigaos/ndk13-include`


### PR DESCRIPTION
This PR adds a section which explains how executables can be compiled for KS1.3.
