### PR TITLE
Add Picasso96API to SDK

### DIFF
--- a/sdk/p96.sdk
+++ b/sdk/p96.sdk
@@ -1,0 +1,13 @@
+Short: Picasso96 retargetable graphics system
+Version: 2.3
+Url: http://wiki.icomp.de/w/images/e/e9/Develop.lha
+
+Picasso96Develop/Include/libraries/Picasso96.i
+Picasso96Develop/Include/autodocs/Picasso96API.doc
+Picasso96Develop/Include/clib/Picasso96_protos.h
+Picasso96Develop/Include/inline/Picasso96.h
+Picasso96Develop/Include/pragmas/Picasso96_pragmas.h
+Picasso96Develop/Include/proto/Picasso96.h
+Picasso96Develop/Include/fd/Picasso96API_lib.fd
+
+


### PR DESCRIPTION
I do not know if adding a seemingly random link to the SDK ( http://wiki.icomp.de/w/images/e/e9/Develop.lha ) is a good idea, though?
