### PR TITLE
Fix stub generation for CAMD SDK's CreateMidi() function

### DIFF
--- a/patches/camd/camd_lib.fd.diff
+++ b/patches/camd/camd_lib.fd.diff
@@ -1,0 +1,11 @@
+--- camd/fd/camd_lib.fd.orig	2020-09-26 20:21:15.315420700 +0100
++++ camd/fd/camd_lib.fd	2020-09-26 20:21:27.785420700 +0100
+@@ -3,7 +3,7 @@
+ ##public
+ LockCAMD(locktype)(d0)
+ UnlockCAMD(lock)(a0)
+-CreateMidiA(name,tags)(a0)
++CreateMidiA(tags)(a0)
+ DeleteMidi(mi)(a0)
+ SetMidiAttrsA(mi,tags)(a0,a1)
+ GetMidiAttrsA(mi,tags)(a0,a1)

--- a/sdk/camd.sdk
+++ b/sdk/camd.sdk
@@ -2,6 +2,8 @@ Short: 	CAMD developer kit for MorphOS
 Version: 37.1
 Url: http://aminet.net/dev/c/camd-morphos-dev.lha
 
+patch : camd_lib.fd.diff
+
 camd/clib/camd_protos.h
 camd/fd/camd_lib.fd = camd.fd
 camd/midi/camd.h

--- a/sdk/install
+++ b/sdk/install
@@ -99,6 +99,11 @@ case $1 in
 				rm -rf $3/m68k-amigaos/${a[2]}
 				ln -s $3/m68k-amigaos/${a[1]} $3/m68k-amigaos/${a[2]}
 			;;
+			patch)
+				patch=patches/$2/${a[1]}
+				echo applying patch $patch
+				patch -N -p0 -r - -d build/$2 < $patch
+			;;
 			*)
 				if [ "$line" != "" ]; then
 					if [ "${a[1]}" == "=" ]; then


### PR DESCRIPTION
Currently it's not possible to compile a simple program that calls the `CreateMidi()` function:
```c
#include <proto/camd.h>
#include <proto/exec.h>

#include <stdlib.h>

struct Library* CamdBase = NULL;
static struct MidiNode* midi_node = NULL;

int main()
{
	CamdBase = OpenLibrary("camd.library", 0L);
	if (!CamdBase)
		return EXIT_FAILURE;

	midi_node = CreateMidi(MIDI_MsgQueue, 2048, MIDI_SysExSize, 1000L, TAG_END);
	if (!midi_node)
		return EXIT_FAILURE;

	DeleteMidi(midi_node);

	return EXIT_SUCCESS;
}
```

Compilation fails with an undefined reference to `CreateMidi`.

This PR includes two small commits to fix it:

- The ability to add a `patch` line in the `*.sdk` files so that we can fixup SDKs.
- A patch for CAMD to fix the problem with its FD file.