### PR TITLE
Add MHI library to SDK

### DIFF
--- a/sdk/mhi.sdk
+++ b/sdk/mhi.sdk
@@ -1,0 +1,17 @@
+Short: mhi.library
+Version: 1.1
+Url: http://aminet.net/mus/play/mhi_dev.lha
+
+mhi_dev/Autodoc/mhi.doc
+mhi_dev/Docs/MHI_Developer.guide
+mhi_dev/Include/clib/mhi_protos.h
+mhi_dev/Include/fd/mhi_lib.fd = mhi.fd
+mhi_dev/Include/proto/mhi.h
+mhi_dev/Include/pragmas/mhi_pragmas.h
+mhi_dev/Include/pragma/mhi_lib.h
+mhi_dev/Include/libraries/mhi.h
+mhi_dev/Include/proto/mhi.h
+
+fd2sfd : mhi.fd clib/mhi_protos.h
+sfdc : mhi.sfd
+stubs : mhi.sfd


### PR DESCRIPTION
Prisma Megamix support, used in ports like Chocolate-Heretic