### PR TITLE
Fix build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -545,7 +545,7 @@ projects/sfdc/configure:
 	@cd projects &&	git clone -b master --depth 4 $(GIT_SFDC)
 	for i in $$(find patches/sfdc/ -type f); \
 	do if [[ "$$i" == *.diff ]] ; \
-		then j=$${i:8}; patch -N "projects/$${j%.diff}" "$$i"; fi ; done
+		then j=$${i:8}; patch -N "projects/$${j%.diff}" "$$i"; retCode=$$?; [[ $$retCode -gt 1 ]] && exit $$retCode; fi ; done; exit 0
 
 # =================================================
 # vasm

--- a/Makefile
+++ b/Makefile
@@ -736,7 +736,7 @@ projects/$(NDK_FOLDER_NAME).info: $(BUILD)/_lha_done download/$(NDK_ARC_NAME).lh
 	@touch projects/$(NDK_FOLDER_NAME).info
 
 download/$(NDK_ARC_NAME).lha:
-	@cd download && wget $(NDK_URL)
+	@cd download && wget $(NDK_URL) -O $(NDK_ARC_NAME).lha
 
 
 # =================================================

--- a/sdk/mui.sdk
+++ b/sdk/mui.sdk
@@ -1,6 +1,6 @@
 Short: Magic User Interface
-Version: 5.0-2016R3
-Url: https://muidev.de/download/MUI%205.0%20-%20Release/MUI-5.0-2016R3-os3.lha
+Version: 5.0-2020R3
+Url: https://github.com/amiga-mui/muidev/releases/download/MUI-5.0-2020R3/MUI-5.0-2020R3-os3.lha
 
 SDK/MUI/Autodocs/MCC/MCC_NumericString.doc
 SDK/MUI/Autodocs/MCC/MCC_BetterBalance.doc


### PR DESCRIPTION
* [NDK39] Make sure NDK39.lha is saved correctly, if the file already existed for some reason but were broken, it would download the file as NDK39-1.lha and make would fail to unpack the broken archive
* [MUI] Update MUI SDK to 2020R3 version, as old URL was no longer valid and caused the script to fail
* [SFDC] Make `patch` return 0 when skipping an already applied patch