### PR TITLE
Add cdplayer.library v37 SDK

### DIFF
--- a/patches/cdplayer/cdplayer.fd.diff
+++ b/patches/cdplayer/cdplayer.fd.diff
@@ -1,0 +1,30 @@
+--- cdplayer.library/include/fd/cdplayer.fd.orig	2022-04-22 22:53:12.738869052 -0700
++++ cdplayer.library/include/fd/cdplayer.fd	2022-04-22 22:53:38.970284940 -0700
+@@ -1,15 +1,15 @@
+ ##base _CDPlayerBase
+ ##bias 30
+-CDEject(io_ptr) (a5)
+-CDPlay(starttrack,endtrack,io_ptr) (a0,a1,a5)
+-CDResume(Mode,io_ptr) (a0,a5)
+-CDStop(io_ptr) (a5)
+-CDJump(Blocks,io_ptr) (a0,a5)
+-CDActive(io_ptr) (a5)
+-CDCurrentTitle(io_ptr) (a5)
+-CDTitleTime(cd_time,io_ptr) (a0,a5)
+-CDGetVolume(vol,io_ptr) (a0,a5)
+-CDSetVolume(vol,io_ptr) (a0,a5)
+-CDReadTOC(toc,io_ptr) (a0,a5)
+-CDInfo(cdi,io_ptr) (a0,a5)
++CDEject(io_ptr)(a5)
++CDPlay(starttrack,endtrack,io_ptr)(a0,a1,a5)
++CDResume(Mode,io_ptr)(a0,a5)
++CDStop(io_ptr)(a5)
++CDJump(Blocks,io_ptr)(a0,a5)
++CDActive(io_ptr)(a5)
++CDCurrentTitle(io_ptr)(a5)
++CDTitleTime(cd_time,io_ptr)(a0,a5)
++CDGetVolume(vol,io_ptr)(a0,a5)
++CDSetVolume(vol,io_ptr)(a0,a5)
++CDReadTOC(toc,io_ptr)(a0,a5)
++CDInfo(cdi,io_ptr)(a0,a5)
+ ##end

--- a/patches/cdplayer/cdplayer_protos.h.diff
+++ b/patches/cdplayer/cdplayer_protos.h.diff
@@ -1,0 +1,12 @@
+--- cdplayer.library/include/clib/cdplayer_protos.orig.h	1995-05-29 11:57:38.000000000 -0700
++++ cdplayer.library/include/clib/cdplayer_protos.h	2022-06-17 22:54:59.342089800 -0700
+@@ -11,7 +11,7 @@
+ #endif
+ 
+ BYTE CDEject (struct IOStdReq *);
+-BYTE CDPlay (UBYTE, UBYTE, struct IOStdReq *);
++BYTE CDPlay (ULONG, ULONG, struct IOStdReq *);
+ BYTE CDResume (BOOL, struct IOStdReq *);
+ BYTE CDStop (struct IOStdReq *);
+ BYTE CDJump (ULONG, struct IOStdReq *);
+

--- a/sdk/cdplayer.sdk
+++ b/sdk/cdplayer.sdk
@@ -1,0 +1,16 @@
+Short: 	Library to play audio from scsi-cdrom
+Version: 37
+Url: http://aminet.net/dev/misc/CDPlayerlib37.lha
+
+patch : cdplayer.fd.diff
+patch : cdplayer_protos.h.diff
+
+cdplayer.library/include/clib/cdplayer_protos.h
+cdplayer.library/include/fd/cdplayer.fd
+cdplayer.library/include/libraries/cdplayer.h
+cdplayer.library/docs/cdplayer.dok = cdplayer.doc	
+cdplayer.library/docs/cdplayer.guide
+
+fd2sfd : cdplayer.fd clib/cdplayer_protos.h
+sfdc : cdplayer.sfd
+stubs : cdplayer.sfd


### PR DESCRIPTION
DOES NOT WORK

The included patch file patches the FD file so fd2sfd will process it.
It removes a whitespace between the parameter list and the register list.