### PR TITLE
pick binutils' needed libgmp from homebrew on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,17 @@ ifneq (m68k-elf,$(TARGET))
 CONFIG_BINUTILS += --disable-plugins
 endif
 
+# FreeBSD, OSX : libs added by the command brew install gmp
+ifeq (Darwin, $(findstring Darwin, $(UNAME_S)))
+	BREW_PREFIX := $$(brew --prefix)
+	CONFIG_BINUTILS += --with-libgmp-prefix=$(BREW_PREFIX)
+endif
+
+ifeq (FreeBSD, $(findstring FreeBSD, $(UNAME_S)))
+	PORTS_PREFIX?=/usr/local
+	CONFIG_BINUTILS += --with-libgmp-prefix=$(PORTS_PREFIX)
+endif
+
 BINUTILS_CMD := $(TARGET)-addr2line $(TARGET)-ar $(TARGET)-as $(TARGET)-c++filt \
 	$(TARGET)-ld $(TARGET)-nm $(TARGET)-objcopy $(TARGET)-objdump $(TARGET)-ranlib \
 	$(TARGET)-readelf $(TARGET)-size $(TARGET)-strings $(TARGET)-strip


### PR DESCRIPTION
Recent binutils need libgmp for the gdb compile. This patch adds the libgmp from Homebrew on Mac.
It is a similar approach as the one already used for gcc.
I also cloned the FreeBSD section from gcc... it might need the same fix.