### PR TITLE
Fixed the NDK 3.9 URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ NDK_FOLDER_NAME_FD   := NDK3.2/FD
 NDK_FOLDER_NAME_SFD  := NDK3.2/SFD
 NDK_FOLDER_NAME_LIBS := NDK3.2/lib
 else
-NDK_URL         := http://www.haage-partner.de/download/AmigaOS/NDK39.lha
+NDK_URL         := http://hp.alinea-computer.de/AmigaOS/NDK39.lha
 NDK_ARC_NAME    := NDK3.9
 NDK_FOLDER_NAME := NDK_3.9/Include
 NDK_FOLDER_NAME_H    := NDK_3.9/Include/include_h


### PR DESCRIPTION
Since the old URL was no longer working I looked for a reliable mirror of NDK 3.9. It's still useful for maintaining backwards compatibility with classic versions of the OS.