### PR TITLE
add doomsound.library sdk

### DIFF
--- a/sdk/doomsound.sdk
+++ b/sdk/doomsound.sdk
@@ -1,0 +1,8 @@
+Short: New Sound & Music Libraries for DOOM ports
+Version: 38.0
+Url: http://aminet.net/game/shoot/DoomSndLibs.lha
+
+doomsound_lib.sfd = doomsound.sfd
+
+sfdc : doomsound.sfd
+clib : doomsound.sfd

--- a/sdk/install
+++ b/sdk/install
@@ -46,6 +46,13 @@ case $1 in
 				mkdir -p $3/m68k-amigaos/lib/sfd/
 				$3/bin/fd2sfd -o $3/m68k-amigaos/lib/sfd/$name.sfd $3/m68k-amigaos/lib/fd/$fd $3/m68k-amigaos/include/$proto || exit 1
 			;;
+			clib)
+				sfd=${a[1]}
+				file=$(basename $sfd)
+				name=${file%????}
+				mkdir -p $3/m68k-amigaos/include/clib/
+				$3/bin/sfdc --mode=clib --target=m68k-amigaos --output=$3/m68k-amigaos/include/clib/${name}_protos.h $3/m68k-amigaos/lib/sfd/$sfd || exit 1
+			;;
 			sfdc)
 				sfd=${a[1]}
 				file=$(basename $sfd)


### PR DESCRIPTION
I added an SDK for doomsound.library used in many Doom ports. The sdk install scrip now also has an option to generate the clib protos from the SFD file.